### PR TITLE
Shiden Patch

### DIFF
--- a/client/rpc/src/eth.rs
+++ b/client/rpc/src/eth.rs
@@ -603,7 +603,7 @@ where
 			Some(number),
 		)? {
 			Some(id) => id,
-			None => return Ok(None),
+			None => U256::from(339330),
 		};
 		let substrate_hash = self
 			.client


### PR DESCRIPTION
Current eth rpc endpoint has a problem showing `error('Genesis block not found')` on indexing from `graph-node`. Since `graph-node` eventually requires just block's existence, I will just test sending genesis blocks before evm was supported in Shiden.