### PR TITLE
Base fee for empty block

### DIFF
--- a/client/rpc/src/eth/block.rs
+++ b/client/rpc/src/eth/block.rs
@@ -199,7 +199,7 @@ where
 							Default::default(),
 							Some(eth_hash),
 							full,
-							None,
+							base_fee,
 						)))
 					} else {
 						Ok(None)


### PR DESCRIPTION
Remove hardcoded `None` and replace it with `base_fee` value (which can be None).