### PR TITLE
fix features of fp-account dependencies

### DIFF
--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -59,8 +59,8 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	# Frontier
-	"fp-evm/std",
 	"fp-account/std",
+	"fp-evm/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -9,12 +9,14 @@ repository = { workspace = true }
 
 [dependencies]
 hex = { version = "0.4.3", default-features = false }
-impl-serde = { workspace = true }
-libsecp256k1 = { workspace = true, default-features = false }
+impl-serde = { workspace = true, optional = true }
+libsecp256k1 = { workspace = true }
 log = { workspace = true }
 scale-codec = { package = "parity-scale-codec", workspace = true }
 scale-info = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
+
+# Substrate
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
@@ -25,14 +27,16 @@ sp-std = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"impl-serde/std",
 	"hex/std",
+	"impl-serde/std",
 	"libsecp256k1/std",
 	"log/std",
-	"serde/std",
+	"scale-codec/std",
+	"scale-info/std",
+	"serde",
 	# Substrate
-	"sp-io/std",
 	"sp-core/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]


### PR DESCRIPTION
This PR ports https://github.com/paritytech/frontier/pull/1025/files the issue with fp-accounts from the Paritytech original frontier repository. The same [patch](https://github.com/PureStake/frontier/commit/d13668c014c229fe786ffff2eed636a3fd2ef67d) was applied to the PureStake repository.

For some mysterious reasons, serde can leak the std feature in the non-std environment for some mysterious reasons. So, it's recommended to make it optional during compilation and enable it only in std env.