### PR TITLE
Add 'CallOrCreateInfo' to 'ValidatedTransaction' apply result

### DIFF
--- a/primitives/ethereum/src/lib.rs
+++ b/primitives/ethereum/src/lib.rs
@@ -23,9 +23,10 @@ pub use ethereum::{
 	TransactionAction, TransactionV2 as Transaction,
 };
 use ethereum_types::{H160, H256, U256};
-use fp_evm::CheckEvmTransactionInput;
+use fp_evm::{CallOrCreateInfo, CheckEvmTransactionInput};
+use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
 use scale_codec::{Decode, Encode};
-use sp_std::vec::Vec;
+use sp_std::prelude::*;
 
 #[repr(u8)]
 #[derive(num_enum::FromPrimitive, num_enum::IntoPrimitive)]
@@ -44,7 +45,7 @@ pub trait ValidatedTransaction {
 	fn apply(
 		source: H160,
 		transaction: Transaction,
-	) -> frame_support::dispatch::DispatchResultWithPostInfo;
+	) -> Result<(PostDispatchInfo, CallOrCreateInfo), DispatchErrorWithPostInfo>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]


### PR DESCRIPTION
1. Add `CallOrCreateInfo` to `apply` result of `ValidatedTransaction`, to support XVM call result query. 
2. Make `Pending` storage public, which is to revert the breaking change in Frontier 0.9.40, to support https://github.com/AstarNetwork/Astar/pull/967

Upstream PR - https://github.com/paritytech/frontier/pull/1099